### PR TITLE
Allow Drush 10

### DIFF
--- a/InstallCommands.php
+++ b/InstallCommands.php
@@ -34,7 +34,7 @@ class InstallCommands extends DrushCommands implements SiteAliasManagerAwareInte
     }
 
     FileCacheFactory::setConfiguration(['default' => ['class' => '\Drupal\Component\FileCache\NullFileCache']]);
-    $source_storage = new FileStorage(config_get_config_directory(CONFIG_SYNC_DIRECTORY));
+    $source_storage = new FileStorage(Settings::get('config_sync_directory'));
 
     if (!$source_storage->exists('core.extension')) {
       $this->io()->warning('Existing configuration to install from not found. If this is your first time using Tome try running "drush tome:init".');
@@ -67,7 +67,7 @@ class InstallCommands extends DrushCommands implements SiteAliasManagerAwareInte
    *   The status code, if the command did not complete successfully.
    */
   public function init() {
-    if (is_dir(config_get_config_directory(CONFIG_SYNC_DIRECTORY)) || is_dir(Settings::get('tome_content_directory', '../content'))) {
+    if (is_dir(Settings::get('config_sync_directory')) || is_dir(Settings::get('tome_content_directory', '../content'))) {
       if (!$this->io()->confirm('Running this command will remove all exported content and configuration. Do you want to continue?', FALSE)) {
         return 0;
       }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Contains global Drush commands for initializing and installing Tome.",
     "type": "drupal-drush",
     "require": {
-        "drush/drush": "^9.6.0"
+        "drush/drush": "^9.6.0 || ^10.0",
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Contains global Drush commands for initializing and installing Tome.",
     "type": "drupal-drush",
     "require": {
-        "drush/drush": "^9.6.0 || ^10.0",
+        "drush/drush": "^9.6.0 || ^10.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This allows tome_drush to be installed on Drupal 9 installations.